### PR TITLE
Support NumPy 1.17.0 or later

### DIFF
--- a/src/age_estimation/cacd_process.py
+++ b/src/age_estimation/cacd_process.py
@@ -43,9 +43,9 @@ def get_counts(data_dic):
 
 def get_data(img_path):
     # pre-process the data for CACD
-    train_list = np.load('../data/CACD_split/train.npy')
-    valid_list = np.load('../data/CACD_split/valid.npy')
-    test_list = np.load('../data/CACD_split/test.npy')
+    train_list = np.load('../data/CACD_split/train.npy', allow_pickle=True)
+    valid_list = np.load('../data/CACD_split/valid.npy', allow_pickle=True)
+    test_list = np.load('../data/CACD_split/test.npy', allow_pickle=True)
     train_dic = get_dic(train_list, img_path)
     print('Training images: %d'%get_counts(train_dic))
     valid_dic = get_dic(valid_list, img_path)
@@ -158,7 +158,7 @@ def main():
 #    for i in tqdm(range(len(onlyfiles))):
 #        landmark_list.append(get_landmarks(onlyfiles[i], args))
 
-    landmark_ref = np.matrix(np.load('../data/CACD_mean_face.npy'))
+    landmark_ref = np.matrix(np.load('../data/CACD_mean_face.npy', allow_pickle=True))
     
     # Points used to line up the images.
     ALIGN_POINTS = list(range(16))

--- a/src/age_estimation/data_prepare.py
+++ b/src/age_estimation/data_prepare.py
@@ -114,12 +114,12 @@ def prepare_db(opt):
     if opt.dataset_name == "FGNET":
         raise NotImplementedError
     elif opt.dataset_name == "CACD":
-        eval_dic = np.load('../data/CACD_split/test_cacd_processed.npy').item()
+        eval_dic = np.load('../data/CACD_split/test_cacd_processed.npy', allow_pickle=True).item()
         if opt.cacd_train:
-            train_dic = np.load('../data/CACD_split/train_cacd_processed.npy').item()
+            train_dic = np.load('../data/CACD_split/train_cacd_processed.npy', allow_pickle=True).item()
             logging.info('Preparing CACD dataset (training with the training set).')
         else:
-            train_dic = np.load('../data/CACD_split/valid_cacd_processed.npy').item()
+            train_dic = np.load('../data/CACD_split/valid_cacd_processed.npy', allow_pickle=True).item()
             logging.info('Preparing CACD dataset (training with the validation set).')
         train_list.append(FacialAgeDataset(train_dic, opt, 'train'))
         eval_list.append(FacialAgeDataset(eval_dic, opt, 'eval'))


### PR DESCRIPTION
The default value of an `allow_pickle` keyword on `numpy.load` has been changed to `False` since [NumPy 1.17.0](https://docs.scipy.org/doc/numpy/release.html#unpickling-while-loading-requires-explicit-opt-in), so I fixed it.

These changes don't affect NumPy 1.10.0 or later, but it is **impossible to run with NumPy 1.9.0 or earlier** because [they don't have the `allow_pickle` keyword](https://docs.scipy.org/doc/numpy-1.9.0/reference/generated/numpy.load.html).